### PR TITLE
cKDTree functionality restored for image transform

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -285,7 +285,7 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
                                            target_x_points.flatten(),
                                            target_y_points.flatten())
 
-    kdtree = scipy.spatial.cKDTree(xyz)
+    kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
     distances, indices = kdtree.query(target_xyz, k=1)
     mask = np.isinf(distances)
 


### PR DESCRIPTION
After changes in SciPy 0.16.x scipy.spatial.cKDTree now hangs during projection of images (see http://stackoverflow.com/questions/31819778/scipy-spatial-ckdtree-running-slowly and http://stackoverflow.com/questions/35637801/cartopy-hanging-during-transform/37532594#37532594).
This edit returns the application of scipy.spatial.cKDTree to its previous functionality.
